### PR TITLE
Normalize to nix paths for archetype name param

### DIFF
--- a/lib/archetype.js
+++ b/lib/archetype.js
@@ -290,7 +290,13 @@ ArchetypeArray.prototype.reduce = function(fn, initial) {
   }, initial);
 };
 
-ArchetypeArray.prototype.store = function(module, params) {
+ArchetypeArray.prototype.store = function(module, _params) {
+  var params = {
+    // Normalize to *nix paths.
+    name: _params.name.replace(/\\/g, '/'),
+    fullpath: _params.fullpath,
+  };
+
   return this.reduce(function(value, archetype) {
     return value
       .then(function(carry) {


### PR DESCRIPTION
[appveyor](https://ci.appveyor.com/project/mzgoddard/ember-loader/build/66#L1938) isn't correctly configured or something to fail on non-zero exit codes from `npm test`.