### PR TITLE
Add optionKey query argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,9 +19,9 @@ module.exports.pitch = function(remainingRequest) {
   this.cacheable && this.cacheable();
   var done = this.async();
   var query = loaderUtils.parseQuery(this.query);
-  var emberOptions = this.options.ember;
+  var emberOptions = this.options[query.optionKey || 'ember'];
   var archetypes = this.archetypes =
-    ArchetypeArray.fromOptions(emberOptions, query);
+    ArchetypeArray.fromOptions(this.options, emberOptions, query);
 
   // FIXME: We need to peer at the file system to know what to load
   // inputFileSystem isn't directly exposed to us. This could break and

--- a/lib/archetype.js
+++ b/lib/archetype.js
@@ -266,20 +266,25 @@ Archetype.prototype.genTab = function(depth) {
   return _.times(depth).map(function() {return '\t';}).join('');
 };
 
+Archetype.prototype.titleCaseFromDashed = titleCaseFromDashed;
 Archetype.prototype.titleCaseFromPath = titleCaseFromPath;
 
 Archetype.prototype.defaults = Archetype.defaults = typeDefaultOptions;
 
-Archetype.fromOptions = function(name, typeOptions) {
+Archetype.fromOptions = function(webpackOptions, name, typeOptions) {
   var archetype = new Archetype();
 
   archetype.name = name;
 
   if (name in typeDefaultOptions && !typeOptions) {
     typeOptions = typeDefaultOptions[name];
-  } else {
+  } else if (typeof typeOptions === 'string') {
+    typeOptions = Archetype.getObject(typeOptions, name, webpackOptions);
+  } else if (!typeOptions) {
     typeOptions = {};
   }
+
+  archetype.options = typeOptions;
 
   if (typeOptions.groupName) {
     archetype.groupName = typeOptions.groupName;
@@ -293,33 +298,66 @@ Archetype.fromOptions = function(name, typeOptions) {
     archetype.suffixName = name;
   }
 
-  if (typeOptions.store) {
-    if (typeof typeOptions.store === 'string') {
-      archetype.store = typeDefaultOptions[typeStoreOptions.store].store;
-    } else {
-      archetype.store = typeOptions.store;
-    }
-  }
+  Archetype.setFunction(
+    archetype, 'store', typeOptions.store, name, webpackOptions
+  );
 
-  if (typeOptions.generate) {
-    if (typeof typeOptions.generate === 'string') {
-      archetype.generate =
-        typeDefaultOptions[typeStoreOptions.generate].generate;
-    } else {
-      archetype.generate = typeOptions.generate;
-    }
-  }
+  Archetype.setFunction(
+    archetype, 'generate', typeOptions.generate, name, webpackOptions
+  );
 
-  if (typeOptions.extend) {
-    archetype.extend = typeOptions.extend;
-  }
+  Archetype.setFunction(
+    archetype, 'extend', typeOptions.extend, name, webpackOptions
+  );
 
   return archetype;
 };
 
+Archetype.getObject = function(value, name, webpackOptions) {
+  var result;
+  if (value === 'default') {
+    result = typeDefaultOptions[name];
+  } else if (_.contains(typeOrderDefault, value)) {
+    result = typeDefaultOptions[value];
+  } else if (value.match(/^default\./)) {
+    result = utils.get(
+      typeDefaultOptions, value.substring('default.'.length)
+    );
+  } else {
+    result = utils.get(webpackOptions, value);
+  }
+
+  if (typeof result === 'string') {
+    result = Archetype.getObject(result, name, webpackOptions);
+  }
+
+  return result;
+};
+
+Archetype.setFunction = function(obj, key, value, name, webpackOptions) {
+  if (value) {
+    var result;
+    if (typeof value === 'string') {
+      result = Archetype.getObject(value, name, webpackOptions);
+
+      if (result) {
+        result = result[key];
+      }
+    } else {
+      result = value;
+    }
+
+    if (result) {
+      obj[key] = result;
+    }
+  }
+};
+
 function ArchetypeArray() {}
 
-ArchetypeArray.fromOptions = function(emberOptions, queryOptions) {
+ArchetypeArray.fromOptions = function(
+  webpackOptions, emberOptions, queryOptions
+) {
   var archetypes = new ArchetypeArray();
 
   archetypes._emberOptions = emberOptions;
@@ -327,15 +365,35 @@ ArchetypeArray.fromOptions = function(emberOptions, queryOptions) {
   archetypes.order = emberOptions.typeOrder || typeOrderDefault;
   archetypes.types = {};
 
+  if (typeof archetypes.order === 'string') {
+    if (archetypes.order === 'default') {
+      archetypes.order = typeOrderDefault;
+    } else {
+      archetypes.order = utils.get(webpackOptions, archetypes.order).typeOrder;
+    }
+  }
+
+  var types = emberOptions.types || {};
+  if (typeof types === 'string') {
+    if (types === 'default') {
+      types = typeDefaultOptions;
+    } else {
+      types = utils.get(webpackOptions, types).types;
+    }
+  }
+
   archetypes.order.forEach(function(archetypeName) {
     archetypes.types[archetypeName] = Archetype.fromOptions(
+      webpackOptions,
       archetypeName,
-      (emberOptions.types || {})[archetypeName]
+      types[archetypeName]
     );
   });
 
   return archetypes;
 };
+
+ArchetypeArray.orderDefaults = typeDefaultOptions;
 
 ArchetypeArray.prototype.get = function(archetypeName) {
   return this.types[archetypeName];

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -158,3 +158,12 @@ var squelchENOENT = function(e) {
     throw e;
   }
 };
+
+exports.get = function(obj, key) {
+  var split = key.split('.');
+  var i, l;
+  for (i = 0, l = split.length; i < l; i++) {
+    obj = obj[split[i]];
+  }
+  return obj;
+};

--- a/test/index.js
+++ b/test/index.js
@@ -143,8 +143,26 @@ describe('components', function() {
     expect(simple.ChildComponent).to.exist;
   });
 
+  it('should load fixture component-simple', function() {
+    var simple = require(
+      '!!..?optionKey=emberWithExternalComponents' +
+        '!./fixtures/component-simple'
+    );
+    expect(Object.keys(simple)).to.have.length.of(1);
+    expect(simple.ChildComponent).to.exist;
+  });
+
   it('should load fixture component-deep', function() {
     var module = require('!!../!./fixtures/component-deep');
+    expect(Object.keys(module)).to.have.length.of(2);
+    expect(module.ShallowComponent).to.exist;
+    expect(module.DeepComponent).to.exist;
+  });
+
+  it('should load fixture component-deep', function() {
+    var module = require(
+      '!!..?optionKey=emberWithExternalComponents!./fixtures/component-deep'
+    );
     expect(Object.keys(module)).to.have.length.of(2);
     expect(module.ShallowComponent).to.exist;
     expect(module.DeepComponent).to.exist;
@@ -156,6 +174,16 @@ describe('components', function() {
     expect(module.ChildComponent).to.exist;
   });
 
+  it('should load fixture component-web-modules', function() {
+    var module = require(
+      '!!..?optionKey=emberWithExternalComponents' +
+        '!./fixtures/component-web-modules'
+    );
+    expect(Object.keys(module)).to.have.length.of(1);
+    expect(module.ChildComponent).to.exist;
+  });
+
+  // TODO 0.1: Drop this test as we will drop componentsDirectories support.
   it('should load fixture component-other-modules', function() {
     var module = require(
       '!!../?componentsDirectories[]=other_modules!' +
@@ -223,6 +251,111 @@ describe('modules', function() {
     );
     expect(module.TEMPLATES).to.not.include.keys(
       'pod/item/component'
+    );
+  });
+
+  it('should load fixture pod with explicit defaults', function() {
+    var module = require('!!..?optionKey=emberWithDefaults!./fixtures/pod');
+    expect(module).to.include.keys(
+      // Model
+      'Application',
+      'ApplicationChildIndexRoute',
+      'ApplicationController',
+      'ApplicationIndexRoute',
+      'ApplicationRoute',
+      'ApplicationView',
+      'INITIALIZERS',
+      'PodItemComponent',
+      'PodListComponent',
+      'PodOverviewComponent',
+      'PodPairComponent',
+      'PodScoreComponent',
+      'PodSuperComponent',
+      'SmallModuleRoute'
+    );
+  });
+
+  it('should load fixture pod with only components', function() {
+    var module = require(
+      '!!..?optionKey=emberWithDefaultString!./fixtures/pod'
+    );
+    expect(module).to.include.keys(
+      'PodItemComponent',
+      'PodListComponent',
+      'PodOverviewComponent',
+      'PodPairComponent',
+      'PodScoreComponent',
+      'PodSuperComponent'
+    );
+  });
+
+  it('should load fixture pod with only components', function() {
+    var module = require(
+      '!!..?optionKey=emberWithDefaultTypes!./fixtures/pod'
+    );
+    expect(module).to.include.keys(
+      'PodItemComponent',
+      'PodListComponent',
+      'PodOverviewComponent',
+      'PodPairComponent',
+      'PodScoreComponent',
+      'PodSuperComponent'
+    );
+  });
+
+  it('should load fixture pod with only components', function() {
+    var module = require(
+      '!!..?optionKey=emberWithNamedDefault!./fixtures/pod'
+    );
+    expect(module).to.include.keys(
+      'PodItemComponent',
+      'PodListComponent',
+      'PodOverviewComponent',
+      'PodPairComponent',
+      'PodScoreComponent',
+      'PodSuperComponent'
+    );
+  });
+
+  it('should load fixture pod with only components', function() {
+    var module = require(
+      '!!..?optionKey=emberWithDottedDefault!./fixtures/pod'
+    );
+    expect(module).to.include.keys(
+      'PodItemComponent',
+      'PodListComponent',
+      'PodOverviewComponent',
+      'PodPairComponent',
+      'PodScoreComponent',
+      'PodSuperComponent'
+    );
+  });
+
+  it('should load fixture pod with only components', function() {
+    var module = require(
+      '!!..?optionKey=emberWithDottedReference!./fixtures/pod'
+    );
+    expect(module).to.include.keys(
+      'PodItemComponent',
+      'PodListComponent',
+      'PodOverviewComponent',
+      'PodPairComponent',
+      'PodScoreComponent',
+      'PodSuperComponent'
+    );
+  });
+
+  it('should load fixture pod with only components', function() {
+    var module = require(
+      '!!..?optionKey=emberWithDottedDoubleReference!./fixtures/pod'
+    );
+    expect(module).to.include.keys(
+      'PodItemComponent',
+      'PodListComponent',
+      'PodOverviewComponent',
+      'PodPairComponent',
+      'PodScoreComponent',
+      'PodSuperComponent'
     );
   });
 

--- a/test/webpack.config.js
+++ b/test/webpack.config.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 module.exports = {
   context: __dirname,
   entry: __dirname + '/index.js',
@@ -15,9 +17,148 @@ module.exports = {
       './bower_components', './node_modules', './web_modules'
     ],
   },
+
   ember: {
     concatComponentsDirectories: [
       'bower_components', 'node_modules', 'web_modules'
     ],
   },
+
+  emberWithDefaults: {
+    typeOrder: 'default',
+    types: 'default',
+  },
+
+  emberWithDefaultString: {
+    typeOrder: [
+      'component'
+    ],
+    types: {
+      component: 'default',
+    },
+  },
+
+  emberWithDefaultTypes: {
+    typeOrder: [
+      'component'
+    ],
+    types: {
+      component: {
+        store: 'default',
+        generate: 'default',
+        extend: 'default',
+      },
+    },
+  },
+
+  emberWithNamedDefault: {
+    typeOrder: [
+      'component'
+    ],
+    types: {
+      component: {
+        store: 'component',
+        generate: 'component',
+        extend: 'component',
+      },
+    },
+  },
+
+  emberWithDottedDefault: {
+    typeOrder: [
+      'component'
+    ],
+    types: {
+      component: {
+        store: 'default.component',
+        generate: 'default.component',
+        extend: 'default.component',
+      },
+    },
+  },
+
+  emberWithDottedReference: {
+    typeOrder: [
+      'component'
+    ],
+    types: {
+      component: {
+        store: 'emberWithDottedDefault.types.component.store',
+        generate: 'emberWithDottedDefault.types.component.generate',
+        extend: 'emberWithDottedDefault.types.component.extend',
+      },
+    },
+  },
+
+  emberWithDottedDoubleReference: {
+    typeOrder: [
+      'component'
+    ],
+    types: {
+      component: 'emberWithDottedReference.types.component',
+    },
+  },
+
+  // TODO 0.1: Remove this comment. This duplicates external_component in
+  // archetype to demonstrate the ability since at that time as a default it'll
+  // be removed.
+  //
+  // Demonstrate including module deps.
+  emberWithExternalComponents: {
+    typeOrder: [
+      'external_component'
+    ],
+    types: {
+      external_component: {
+        store: function(module, params) {
+          // External Components.
+          var match = /^module_directory\/.*-component-(.*)/.exec(params.name);
+          if (match) {
+            // eg ChildComponent
+            var casedName = this.titleCaseFromDashed(match[1]) + 'Component';
+            module.EXTERNAL_COMPONENTS = module.EXTERNAL_COMPONENTS || {};
+            module.EXTERNAL_COMPONENTS[casedName] = this.storeMatch({
+              name: casedName,
+              fullpath: params.fullpath,
+            });
+            return module;
+          }
+        },
+
+        generate: function(match, depth) {
+          var tab0 = this.genTab(depth);
+          var tab1 = this.genTab(depth + 1);
+          var emberLoader = path.join(__dirname, '..');
+          return [
+            '{',
+            tab1 + '"component": require(' +
+              JSON.stringify(match.fullpath) + '),',
+            tab1 + '"package": require("!!' +
+              JSON.stringify(emberLoader).replace(/^"|"$/g, '') +
+              '?ignoreOverrides&depsLookup[]=modules!' +
+              JSON.stringify(match.fullpath).substring(1) + ')',
+            tab0 + '}'
+          ].join('\n');
+        },
+
+        extend: function(merged, auto, manual) {
+          var key;
+          for (key in merged.EXTERNAL_COMPONENTS) {
+            var value = merged.EXTERNAL_COMPONENTS[key];
+            var subkey;
+            for (subkey in value.package) {
+              if (!merged[subkey]) {
+                merged[subkey] = value.package[subkey];
+              }
+            }
+            if (!merged[key]) {
+              merged[key] = value.component;
+            }
+          }
+          delete merged.EXTERNAL_COMPONENTS;
+        },
+      },
+    },
+  },
+
 };


### PR DESCRIPTION
`optionKey` query parameter lets multiple ember-loader configurations be dictated in the webpack configuration.