### PR TITLE
Replace use of resolve.modulesDirectories with ember option

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,8 +49,8 @@ module.exports.pitch = function(remainingRequest) {
     // TODO 0.1: Remove query.componentsDirectories
     var componentDirs = (query.componentsDirectories || [])
       // TODO 0.1: Remove concatComponentsDirectories
-      .concat(emberOptions && emberOptions.concatComponentsDirectories || [])
-      .concat(this.options.resolve.modulesDirectories || []);
+      .concat(emberOptions.concatComponentsDirectories || [])
+      .concat(emberOptions.modulesDirectories || []);
     componentDirs = _.uniq(componentDirs);
     if (componentDirs.length === 0) {
       componentDirs = ['node_modules'];

--- a/test/webpack.config.js
+++ b/test/webpack.config.js
@@ -22,6 +22,9 @@ module.exports = {
     concatComponentsDirectories: [
       'bower_components', 'node_modules', 'web_modules'
     ],
+    modulesDirectories: [
+      'bower_components', 'node_modules', 'web_modules'
+    ],
   },
 
   emberWithDefaults: {
@@ -105,6 +108,10 @@ module.exports = {
   //
   // Demonstrate including module deps.
   emberWithExternalComponents: {
+    modulesDirectories: [
+      'bower_components', 'node_modules', 'web_modules'
+    ],
+
     typeOrder: [
       'external_component'
     ],


### PR DESCRIPTION
resolve.modulesDirectories can be configured in ways that will utterly
destroy webpack in watch mode. Having a dedicated ember option is a
work around until reading dependencies from a package.json is
implemented and the ember resolver is used to find module deps.