### PR TITLE
Don't watch module folders as context deps

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -21,9 +21,6 @@ exports.findModuleDeps = function(request, subdir) {
         path.resolve(request, subdir, dep[0])
       ]]);
     }, [])
-    .then(function(v) {
-      return v.concat([[subdir, path.resolve(request, subdir), 'context']]);
-    })
     .catch(squelchENOENT);
 };
 


### PR DESCRIPTION
Not yet sure if there is a safe way to do this. For a complex project
using this multiple ember-loaded modules can result in webpack
infinitely looping because of this leaking file descriptors and
crashing applications. So until a safe way is figured out modules
adding dependencies will need to trigger a rebuild some other way or
restart their dev server.