### PR TITLE
Remove use of forever with testing

### DIFF
--- a/.testem.js
+++ b/.testem.js
@@ -1,6 +1,5 @@
 const path = require('path');
 
-const foreverBin = 'node_modules/.bin/forever';
 const webpackBin = path.resolve(__dirname, 'node_modules/.bin/webpack');
 const webpackConfig = ' --config test/webpack.config.js';
 
@@ -8,25 +7,13 @@ module.exports = {
   framework: 'mocha',
   src_files: ['test/tmp/*.js', 'test/**/*.js', '*.js', 'lib/*.js'],
   serve_files: ['test/tmp/*.js'],
-  on_start:
-    foreverBin + ' stop ' + webpackBin + ';\n' +
-    webpackBin + webpackConfig + ' -d;\n' +
-    foreverBin + ' start -c node ' + webpackBin + ' --watch -d' + webpackConfig,
-  on_exit:
-    foreverBin + ' stop ' + webpackBin,
+  on_start: {
+    command: webpackBin + ' --watch -d' + webpackConfig,
+    wait_for_text: '[emitted]',
+  },
   routes: {
     '/mocha': 'node_modules/mocha',
     '/bundle.js': 'test/tmp/bundle.js',
     '/index.html': 'test/index.html'
   }
 };
-
-if (process.platform === 'win32') {
-  // forever doesn't currently seem to be able to work on windows due to path
-  // issues and other things. For now windows will have to live with a larger
-  // cycle for live development with testing. A benefit to this will be live of
-  // the loader code and not just the test code.
-  module.exports.on_start = '';
-  module.exports.on_exit = '';
-  module.exports.before_tests = webpackBin + webpackConfig + ' -d';
-}

--- a/package.json
+++ b/package.json
@@ -17,12 +17,10 @@
     "bower": "^1.3.12",
     "chai": "^1.9.1",
     "ember-templates-loader": "^0.2.1",
-    "forever": "^0.11.1",
-    "install": "^0.1.7",
     "mocha": "^1.20.1",
     "raw-loader": "^0.5.1",
     "script-loader": "^0.5.2",
-    "testem": "^0.6.16",
+    "testem": "^0.8.0",
     "webpack": "^1.3.1-beta1"
   },
   "dependencies": {


### PR DESCRIPTION
testem can launch a process and wait for it to say something before continuing. While wrapping up, testem will shut this process down. Using this we don't need forever to launch and shut down the process.