### PR TITLE
Change extend url to be inside ember-loader's install

### DIFF
--- a/lib/archetype.js
+++ b/lib/archetype.js
@@ -496,10 +496,13 @@ ArchetypeArray.prototype.extendUrl = function(loader) {
     context: loader.options.context,
     content: content,
   });
-  extendUrl = path.join(require('os').tmpdir(), extendUrl);
+  extendUrl = path.join(__dirname, '..', '.tmp', extendUrl);
 
   this._extendUrl = this._emberOptions._extendUrl = extendUrl;
 
+  try {
+    fs.mkdirSync(path.join(__dirname, '..', '.tmp'));
+  } catch (e) {}
   try {
     if (fs.readFileSync(this._extendUrl, 'utf8') !== content) {
       fs.writeFileSync(this._extendUrl, content);


### PR DESCRIPTION
Old tmp directory url had some weird side effects with chokaidar picking up file changes in other tmp directory items that when quickly destroyed would cause webpack to crash because of an unexpected error. Also resulted in all ember-loader items to rebuild on any of them changing.
